### PR TITLE
fix managed_policy_arn deprecated argument 

### DIFF
--- a/modules/document-ingestion/iam.tf
+++ b/modules/document-ingestion/iam.tf
@@ -41,11 +41,6 @@ resource "aws_iam_role" "ingestion_api_datasource" {
     }]
   })
 
-  managed_policy_arns = [
-    "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-    "arn:aws:iam::aws:policy/AmazonEventBridgeFullAccess",
-  ]
-
   tags = local.combined_tags
 }
 
@@ -54,6 +49,25 @@ resource "aws_iam_role_policy" "ingestion_api_datasource" {
   role   = aws_iam_role.ingestion_api_datasource.id
   policy = data.aws_iam_policy_document.ingestion_api_datasource.json
 }
+
+data "aws_iam_policy" "AWSLambdaBasicExecutionRole" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_iam_policy" "AmazonEventBridgeFullAccess" {
+  arn = "arn:aws:iam::aws:policy/AmazonEventBridgeFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "ingestion_api_datasource_lambda_managed_policies_attach" {
+  role       = aws_iam_role.ingestion_api_datasource.name
+  policy_arn = aws_iam_policy.AWSLambdaBasicExecutionRole.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ingestion_api_datasource_eventbridge_managed_policies_attach" {
+  role       = aws_iam_role.ingestion_api_datasource.name
+  policy_arn = aws_iam_policy.AmazonEventBridgeFullAccess.arn
+}
+
 
 ############################################################################################################
 # IAM Role for Ingestion Input Validation Lambda

--- a/modules/document-ingestion/iam.tf
+++ b/modules/document-ingestion/iam.tf
@@ -60,12 +60,12 @@ data "aws_iam_policy" "AmazonEventBridgeFullAccess" {
 
 resource "aws_iam_role_policy_attachment" "ingestion_api_datasource_lambda_managed_policies_attach" {
   role       = aws_iam_role.ingestion_api_datasource.name
-  policy_arn = aws_iam_policy.AWSLambdaBasicExecutionRole.arn
+  policy_arn = data.aws_iam_policy.AWSLambdaBasicExecutionRole.arn
 }
 
 resource "aws_iam_role_policy_attachment" "ingestion_api_datasource_eventbridge_managed_policies_attach" {
   role       = aws_iam_role.ingestion_api_datasource.name
-  policy_arn = aws_iam_policy.AmazonEventBridgeFullAccess.arn
+  policy_arn = data.aws_iam_policy.AmazonEventBridgeFullAccess.arn
 }
 
 


### PR DESCRIPTION
managed_policy_arn deprecated argument is fixed for module.genai_doc_ingestion.module.document_ingestion.aws_iam_role.ingestion_api_datasource